### PR TITLE
#77 replace png with svg logo

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/bcabeb288a5c934278acd20b479ab8da494f2711/fluentd/icon/color/fluentd-icon-color.png"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/fluentd/icon/color/fluentd-icon-color.svg?sanitize=true"
   display_name: Fluentd
   sub_title: Logging
   project_url: "https://github.com/fluent/fluentd"


### PR DESCRIPTION
https://github.com/crosscloudci/ci-dashboard/issues/77

Changes made: 
  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/fluentd/icon/color/fluentd-icon-color.svg?sanitize=true"