### PR TITLE
update logo w/ project directory URL

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/fluentd/icon/color/fluentd-icon-color.svg?sanitize=true"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/icon/color/fluentd-icon-color.svg?sanitize=true"
   display_name: Fluentd
   sub_title: Logging
   project_url: "https://github.com/fluent/fluentd"


### PR DESCRIPTION
crosscloudci/ci-dashboard#90

Changes made: add /projects/ to URL

logo_url:

https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/icon/color/fluentd-icon-color.svg