### PR TITLE
Enable Fluentd v1.6.0 on production 

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.5.1"
+  stable_ref: "v1.5.2"
   head_ref: "master"   
  


### PR DESCRIPTION
- Enable Fluentd v1.6.0 on production (cncf.ci) via fluentd-configuration production branch
- https://github.com/crosscloudci/crosscloudci/issues/159