### PR TITLE
enable fluentd v1.6.1 on master

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.6.0"
+  stable_ref: "v1.6.1"
   head_ref: "master"   
  


### PR DESCRIPTION
enable fluentd v1.6.1 on master
- released on 2019-07-11