### PR TITLE
enable fluentd v1.6.2 to cncf.ci

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.5.1"
+  stable_ref: "v1.5.2"
   head_ref: "master"   
  


### PR DESCRIPTION
enable fluentd v1.6.2

- build passed on staging