### PR TITLE
enable Fluentd v1.7.3 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.7.2"
+  stable_ref: "v1.7.3"
   head_ref: "master"   
  


### PR DESCRIPTION
enable Fluentd v1.7.3
- released on Oct 1, 2019