### PR TITLE
Update Stable to v1.10.0 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.9.3"
+  stable_ref: "v1.10.0"
   head_ref: "master"   
  


### PR DESCRIPTION
## Description

v1.10.0 was release on 3-24-2020
- update stable on dev

## Issues: (internal issue)
https://github.com/vulk/cncf_ci/issues/72

## How has this been tested:
* [x] Have not tested


## Types of changes:
*[x] Version update (add to template)

##Checklist:
*[x] No updates required
