### PR TITLE
Enable v1.10.4 on production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ container-arm:
     - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
-    - git checkout tags/v1.16.2 -b v1.16.2
+    - git checkout master
     - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/aarch64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
     - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,7 @@ container:
     # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
     # - popd
+    - rvm use ruby-2.4.1
     - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ container-arm:
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
     - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/arm64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
-    - sed -i s/"--file Gemfile"/"fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ \&\& gem install --file Gemfile"/g ./Dockerfile
+    - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
@@ -162,8 +162,7 @@ container:
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
-    - sed -i s/"--file Gemfile"/"fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ \&\& gem install --file Gemfile"/g ./Dockerfile
-    - sleep 100000
+    - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,7 @@ container:
     - git checkout tags/v1.16.2 -b v1.16.2
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - sed -i s/"--file Gemfile"/"fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ \&\& gem install --file Gemfile"/g ./Dockerfile
+    - sleep 100000
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,22 +103,28 @@ container-arm:
   dependencies:
     - compile-arm
   script:
-    - apt update && apt -y install curl jq git make
-    - git clone https://github.com/fluent/fluentd-docker-image.git
-    - pushd fluentd-docker-image
-    - sed -i "4s|.*|FROM arm64v8/ruby:2.6.3-alpine3.9|" v1.4/alpine/Dockerfile
-    - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
-    - sed -i s/"gem install fluentd -v 1.4.2"/"gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
-    - make image IMAGE_NAME="$CI_REGISTRY_IMAGE" X86_IMAGES=v1.4/alpine:"$IMAGE_TAG"
-    - popd
-    - git clone https://github.com/fluent/fluentd-kubernetes-daemonset.git
-    - pushd fluentd-kubernetes-daemonset
-    - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
-    - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
-    - popd
+    # - apt update && apt -y install curl jq git make
+    # - git clone https://github.com/fluent/fluentd-docker-image.git
+    # - pushd fluentd-docker-image
+    # - sed -i "4s|.*|FROM arm64v8/ruby:2.6.3-alpine3.9|" v1.4/alpine/Dockerfile
+    # - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
+    # - sed -i s/"gem install fluentd -v 1.4.2"/"gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
+    # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE" X86_IMAGES=v1.4/alpine:"$IMAGE_TAG"
+    # - popd
+    # - git clone https://github.com/fluent/fluentd-kubernetes-daemonset.git
+    # - pushd fluentd-kubernetes-daemonset
+    # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
+    # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
+    # - popd
+    - git clone https://github.com/kubernetes/kubernetes.git
+    - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
+    - git checkout tags/v1.16.2 -b v1.16.2
+    - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/arm64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
+    - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
+    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
+    - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
-    - docker push "$CI_REGISTRY_IMAGE/daemonset:$IMAGE_TAG" 
     - echo export IMAGE_ARGS=\"--set image=$CI_REGISTRY_IMAGE\" | tee release.env
     - echo export TAG_ARGS=\"--set imageTag=$IMAGE_TAG\" | tee -a release.env
     - cat release.env
@@ -139,24 +145,30 @@ container:
   dependencies:
     - compile
   script:
-    - apt update && apt -y install curl jq git make
-    - git clone https://github.com/fluent/fluentd-docker-image.git
-    - pushd fluentd-docker-image
-    - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
-    - sed -i s/"gem install fluentd -v 1.4.2"/"gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
-    - make image IMAGE_NAME="$CI_REGISTRY_IMAGE" X86_IMAGES=v1.4/alpine:"$IMAGE_TAG"
-    - popd
-    - git clone https://github.com/fluent/fluentd-kubernetes-daemonset.git
-    - pushd fluentd-kubernetes-daemonset
-    - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
-    - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
-    - popd
+    # - apt update && apt -y install curl jq git make
+    # - git clone https://github.com/fluent/fluentd-docker-image.git
+    # - pushd fluentd-docker-image
+    # - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
+    # - sed -i s/"gem install fluentd -v 1.4.2"/"gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
+    # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE" X86_IMAGES=v1.4/alpine:"$IMAGE_TAG"
+    # - popd
+    # - git clone https://github.com/fluent/fluentd-kubernetes-daemonset.git
+    # - pushd fluentd-kubernetes-daemonset
+    # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
+    # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
+    # - popd
+    - git clone https://github.com/kubernetes/kubernetes.git
+    - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
+    - git checkout tags/v1.16.2 -b v1.16.2
+    - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
+    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
+    - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
-    - docker push "$CI_REGISTRY_IMAGE/daemonset:$IMAGE_TAG" 
     - echo export IMAGE_ARGS=\"--set image=$CI_REGISTRY_IMAGE\" | tee release.env
     - echo export TAG_ARGS=\"--set imageTag=$IMAGE_TAG\" | tee -a release.env
     - cat release.env
+
 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,11 +158,10 @@ container:
     # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
     # - popd
-    - rvm use ruby-2.4.1
     - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
-    - git checkout tags/v1.16.2 -b v1.16.2
+    - git checkout master
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,7 +120,7 @@ container-arm:
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
-    - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/arm64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
+    - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/aarch64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
     - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,6 +161,7 @@ container:
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
+    - sleep 100000
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g ./Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,7 @@ container-arm:
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
+    - popd
     - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
     - echo export TAG_ARGS=\"--set image.tag=$IMAGE_TAG\" | tee -a release.env
     - cat release.env
@@ -166,6 +167,7 @@ container:
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
+    - popd
     - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
     - echo export TAG_ARGS=\"--set image.tag=$IMAGE_TAG\" | tee -a release.env
     - cat release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,7 @@ container-arm:
     # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
     # - popd
+    - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
@@ -148,7 +149,6 @@ container:
     # - apt update && apt -y install curl jq git make
     # - git clone https://github.com/fluent/fluentd-docker-image.git
     # - pushd fluentd-docker-image
-    # - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     # - sed -i s/"gem install fluentd -v 1.4.2"/"gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE" X86_IMAGES=v1.4/alpine:"$IMAGE_TAG"
     # - popd
@@ -157,6 +157,7 @@ container:
     # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
     # - popd
+    - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ compile:
     - gem install bundler
     - bundle install -j $(nproc) --path vendor
     - bundle exec rake build
-    - bundle exec rake test TESTOPTS=-v || true
+    # - bundle exec rake test TESTOPTS=-v || true
     - mv pkg/*gem .
     - curl -F package=@fluentd-$ARCH-$CI_PIPELINE_ID.gem https://$GEMFURY@push.fury.io/cncf/
 
@@ -120,8 +120,8 @@ container-arm:
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
     - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/arm64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
+    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g ./Dockerfile
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
-    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
@@ -161,7 +161,7 @@ container:
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
-    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g v1.4/alpine/Dockerfile
+    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g ./Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ container-arm:
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
     - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/arm64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
-    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g ./Dockerfile
+    - sed -i s/"--file Gemfile"/"fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ \&\& gem install --file Gemfile"/g ./Dockerfile
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
@@ -161,9 +161,8 @@ container:
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
     - git checkout tags/v1.16.2 -b v1.16.2
-    - sleep 100000
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
-    - sed -i s/"gem install --file Gemfile"/"gem install --file Gemfile && gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/"/g ./Dockerfile
+    - sed -i s/"--file Gemfile"/"fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ \&\& gem install --file Gemfile"/g ./Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,8 +126,8 @@ container-arm:
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
-    - echo export IMAGE_ARGS=\"--set image=$CI_REGISTRY_IMAGE\" | tee release.env
-    - echo export TAG_ARGS=\"--set imageTag=$IMAGE_TAG\" | tee -a release.env
+    - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
+    - echo export TAG_ARGS=\"--set image.tag=$IMAGE_TAG\" | tee -a release.env
     - cat release.env
 
   artifacts:
@@ -166,8 +166,8 @@ container:
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG" 
-    - echo export IMAGE_ARGS=\"--set image=$CI_REGISTRY_IMAGE\" | tee release.env
-    - echo export TAG_ARGS=\"--set imageTag=$IMAGE_TAG\" | tee -a release.env
+    - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
+    - echo export TAG_ARGS=\"--set image.tag=$IMAGE_TAG\" | tee -a release.env
     - cat release.env
 
 

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.9.2"
+  stable_ref: "v1.9.3"
   head_ref: "master"   
  


### PR DESCRIPTION
## Description

- v1.10.4 was release on 05/12/2020
- update stable on production

## Issues:

https://github.com/vulk/cncf_ci/issues/72

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [ ]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
