### PR TITLE
Enable v1.11.0 on staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ container-arm:
     - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
-    - git checkout tags/v1.16.2 -b v1.16.2
+    - git checkout master
     - sed -i s/"LD_PRELOAD=\/usr\/lib\/x86_64-linux-gnu\/libjemalloc.so.1"/"LD_PRELOAD=\/usr\/lib\/aarch64-linux-gnu\/libjemalloc.so.1"/g ./Dockerfile
     - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,7 @@ container:
     # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
     # - popd
+    - rvm use ruby-2.4.1
     - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,11 +158,10 @@ container:
     # - sed -i "4s|.*|FROM $CI_REGISTRY_IMAGE:$IMAGE_TAG|" docker-image/v0.12/alpine-syslog/Dockerfile
     # - make image IMAGE_NAME="$CI_REGISTRY_IMAGE/daemonset" DOCKERFILE=v0.12/alpine-syslog VERSION="$IMAGE_TAG"
     # - popd
-    - rvm use ruby-2.4.1
     - export IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - git clone https://github.com/kubernetes/kubernetes.git
     - pushd ./kubernetes/cluster/addons/fluentd-elasticsearch/fluentd-es-image
-    - git checkout tags/v1.16.2 -b v1.16.2
+    - git checkout master
     - sed -i s/"gem 'fluentd'"/"#gem 'fluentd'"/g ./Gemfile
     - sed -i s/"--file Gemfile"/"--file Gemfile \&\& gem install fluentd-$ARCH -v $CI_PIPELINE_ID --source https:\/\/gem.fury.io\/cncf\/ --force"/g ./Dockerfile
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.9.2"
+  stable_ref: "v1.9.3"
   head_ref: "master"   
  


### PR DESCRIPTION
Build passes as expected: https://gitlab.dev.cncf.ci/fluent/fluentd/-/jobs/198821

## Description

- v1.11.0 was released on 06-04-2020
- update stable on staging

## Issues:

https://github.com/vulk/cncf_ci/issues/72

How Has This Been Tested?
---
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested with trigger client against
  - [ ]  cidev.cncf.ci
  - [ ]  dev.cncf.ci
  - [ ]  staging.cncf.ci
  - [ ]  cncf.ci (production)
- [ ] Browser tested on staging.cncf.ci
- [x] Manually tested on https://gitlab.dev.cncf.ci web ui - Build Succeeded
- [ ] Have not tested

Types of changes:
---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Version update

Checklist:
---
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required
