### PR TITLE
Enable v1.11.1 on staging

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.11.0"
+  stable_ref: "v1.11.1"
   head_ref: "master"   
  

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,6 +6,6 @@ project:
   arch:
     - "amd64"
     - "arm64"  
-  stable_ref: "v1.10.4"
+  stable_ref: "v1.11.0"
   head_ref: "master"   
  


### PR DESCRIPTION
Build passed as expected - https://gitlab.dev.cncf.ci/fluent/fluentd/-/jobs/200310

## Description

- v1.11.1 was released on 06/22/2020
- update stable on dev

## Issues:

https://github.com/vulk/cncf_ci/issues/72

How Has This Been Tested?
---
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested with trigger client against
  - [ ]  cidev.cncf.ci
  - [ ]  dev.cncf.ci
  - [ ]  staging.cncf.ci
  - [ ]  cncf.ci (production)
- [ ] Browser tested on staging.cncf.ci
- [x] Manually tested on https://gitlab.dev.cncf.ci web ui - Build Succeeded
- [ ] Have not tested

Types of changes:
---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Version update

Checklist:
---
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required
